### PR TITLE
Support APK Build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.83.0"
 [dependencies]
 image = "0.25.6"
 log = "0.4.27"
-reqwest = { version = "0.12.15", features = ["json"] }
+reqwest = { version = "0.12.15", default-features = false, features = ["json"] }
 serde = { version = "1.0.219", features = ["derive"] }
 suppaftp = "6.2.0"
 texpresso = "2.0.1"


### PR DESCRIPTION
Disable default features for `reqwest` dependency because default TLS feature breaks APK build